### PR TITLE
Set role name

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
+  role_name: ntpd
   author: Juwai IQI
   description: Install ntpd
   company: Juwai IQI


### PR DESCRIPTION
## Summary of changes

Set the role name in meta data file. I think this is how to tell Galaxy what name to use. Right now Galaxy imports it as `ansible_role_ntpd`.

## How to Test

Nothing to test
